### PR TITLE
added quick and dirty lsp support to haskell module

### DIFF
--- a/modules/lang/haskell/+lsp.el
+++ b/modules/lang/haskell/+lsp.el
@@ -2,7 +2,4 @@
 ;;;###if (featurep! +lsp)
 
 (def-package! lsp-haskell
-  :after haskell-mode
-  :init
-  (add-hook 'haskell-mode-hook #'lsp-haskell-enable)
-  (add-hook 'haskell-mode-hook 'flycheck-mode))
+  :hook (haskell-mode . lsp-haskell-enable))

--- a/modules/lang/haskell/+lsp.el
+++ b/modules/lang/haskell/+lsp.el
@@ -1,0 +1,8 @@
+;;; +lsp.el --- description -*- lexical-binding: t; -*-
+;;;###if (featurep! +lsp)
+
+(def-package! lsp-haskell
+  :after haskell-mode
+  :init
+  (add-hook 'haskell-mode-hook #'lsp-haskell-enable)
+  (add-hook 'haskell-mode-hook 'flycheck-mode))

--- a/modules/lang/haskell/config.el
+++ b/modules/lang/haskell/config.el
@@ -1,7 +1,8 @@
 ;;; lang/haskell/config.el -*- lexical-binding: t; -*-
 
 (cond ((featurep! +intero) (load! "+intero"))
-      ((featurep! +dante)  (load! "+dante")))
+      ((featurep! +dante)  (load! "+dante"))
+      ((featurep! +lsp)    (load! "+lsp")))
 
 
 ;;
@@ -11,4 +12,3 @@
 (after! haskell-mode
   (set-repl-handler! 'haskell-mode #'switch-to-haskell)
   (add-to-list 'completion-ignored-extensions ".hi"))
-

--- a/modules/lang/haskell/doctor.el
+++ b/modules/lang/haskell/doctor.el
@@ -12,3 +12,8 @@
   (unless (executable-find "stack")
     (warn! "Couldn't find stack. Intero will not work")))
 
+;;;
+(when (featurep! +lsp)
+  (unless (executable-find "hie")
+    (warn! "Couldnt find the Haskell IDE Engine. LSP support will not work.")))
+

--- a/modules/lang/haskell/packages.el
+++ b/modules/lang/haskell/packages.el
@@ -4,11 +4,13 @@
 (package! haskell-mode)
 
 ;;
-(cond ((featurep! +dante)
+(cond
+ ((featurep! +lsp) (depends-on! :tools lsp
+                                (package! lsp-haskell)))
+ ((featurep! +dante)
        (package! dante)
        (when (featurep! :completion company)
          (package! company-ghc)))
       (t
        (package! intero)
        (package! hindent)))
-


### PR DESCRIPTION
I've added rudimentary support for lsp to the haskell module.

todo still:
- [ ] test how nicely `lsp-haskell` plays with `dante` and `intero`. Currently they're mutually exclusive.
- [x] add a `hie` executable check to `doctor.el`