### PR TITLE
fix lsp conf for rust(lsp-rust has been deprecated)

### DIFF
--- a/modules/lang/rust/config.el
+++ b/modules/lang/rust/config.el
@@ -28,9 +28,13 @@
   :after rust-mode
   :config (add-hook 'rust-mode-hook #'flycheck-rust-setup))
 
-(def-package! lsp-typescript
-  :when (featurep! +lsp)
-  :when (featurep! :tools lsp)
-  :hook (rust-mode . lsp-rust-enable)
-  :init
-  (setq lsp-rust-rls-command '("rustup" "run" "nightly" "rls")))
+(when (featurep! +lsp)
+       (depends-on! :tools lsp)
+       (lsp-register-client
+        (make-lsp-client :new-connection (lsp-stdio-connection
+                                          '("rustup" "run" "nightly" "rls")
+                                          )
+                         :major-modes '(rust-mode rustic-mode)
+                         :priority -1
+                         :server-id 'rls
+                         :notification-handlers (lsp-ht ("window/progress" 'lsp-clients--rust-window-progress)))))

--- a/modules/lang/rust/packages.el
+++ b/modules/lang/rust/packages.el
@@ -10,7 +10,6 @@
   (package! flycheck-rust))
 
 (cond ((and (depends-on! :tools lsp)
-            (featurep! +lsp))
-       (package! lsp-rust))
+            (featurep! +lsp)))
       ((when (featurep! :completion company)
          (package! company-racer))))


### PR DESCRIPTION
from https://github.com/emacs-lsp/lsp-rust/pull/38:

> this package is deprecated and minimal configuration of rust is included as part of lsp-clients.el in lsp-mode repo.

So [lsp-mode](https://github.com/emacs-lsp/lsp-mode) is enough. The only thing should be noticed is that `rls-preview` is used here, so `'("rustup" "run" "nightly" "rls")'("rustup" "run" "nightly" "rls")` is still required.