### PR TITLE
add orderless style dispatchers

### DIFF
--- a/modules/completion/selectrum/config.el
+++ b/modules/completion/selectrum/config.el
@@ -24,6 +24,18 @@
   (add-hook 'selectrum-candidate-selected-hook #'selectrum-prescient--remember)
   (add-hook 'selectrum-candidate-inserted-hook #'selectrum-prescient--remember))
 
+(defun flex-if-twiddle (pattern _index _total)
+  (when (string-suffix-p "~" pattern)
+    `(orderless-flex . ,(substring pattern 0 -1))))
+
+(defun first-initialism (pattern index _total)
+  (if (= index 0) 'orderless-initialism))
+
+(defun without-if-bang (pattern _index _total)
+  "Define a '!not' exclusion prefix for literal strings."
+  (when (string-prefix-p "!" pattern)
+    `(orderless-without-literal . ,(substring pattern 1))))
+
 (use-package! orderless
   :when (featurep! +orderless)
   :defer t
@@ -36,6 +48,9 @@
   (setq completion-styles '(orderless))
   (setq orderless-skip-highlighting (lambda () selectrum-active-p))
   (setq selectrum-highlight-candidates-function #'orderless-highlight-matches))
+  (setq orderless-matching-styles '(orderless-regexp)
+        orderless-style-dispatchers '(flex-if-twiddle
+                                      without-if-bang))
 
 (use-package! consult
   :defer t


### PR DESCRIPTION
Not sure if this belongs in the module, but I find this super useful. Here's them combined; note the highlighting of the different match styles.

![Screenshot from 2021-04-01 20-34-03](https://user-images.githubusercontent.com/1134/113367566-4fb36b00-932a-11eb-83fa-4762badc8e54.png)

------

Add orderless style dispatchers, with the examples from the orderless 
README.

https://github.com/oantolin/orderless#style-dispatchers