### PR TITLE
Selectrum

### DIFF
--- a/modules/completion/selectrum/config.el
+++ b/modules/completion/selectrum/config.el
@@ -81,6 +81,12 @@
   (setq consult-async-input-debounce 0.5)
   (setq consult-async-input-throttle 0.8))
 
+(use-package! consult-xref
+  :commands (consult-xref)
+  :init
+  (setq xref-show-xrefs-function #'consult-xref
+        xref-show-definitions-function #'consult-xref))
+
 (use-package! consult-flycheck
   :when (featurep! :checkers syntax)
   :after (consult flycheck))

--- a/modules/completion/selectrum/config.el
+++ b/modules/completion/selectrum/config.el
@@ -10,7 +10,8 @@
     (setq completion-styles '(substring partial-completion)))
   :config
   (setq selectrum-fix-vertical-window-height 17
-        selectrum-max-window-height 17)
+        selectrum-max-window-height 17
+        projectile-completion-system 'default)
   (defadvice! +selectrum-refresh-on-cycle (&rest _)
     :after 'marginalia-cycle
     (when (bound-and-true-p selectrum-mode) (selectrum-exhibit))))

--- a/modules/config/default/autoload/search.el
+++ b/modules/config/default/autoload/search.el
@@ -75,6 +75,8 @@ If prefix ARG is set, prompt for a known project to search from."
            (+ivy/project-search nil symbol))
           ((featurep! :completion helm)
            (+helm/project-search nil symbol))
+          ((featurep! :completion selectrum)
+           (+selectrum/project-search nil symbol))
           ((rgrep (regexp-quote symbol))))))
 
 ;;;###autoload


### PR DESCRIPTION
this is a microscopic PR that addresses some minor issues (IMO; or maybe they are design choices I haven't yet understood) with the Selectrum PR.

Note that the first commit sets up a selectrum specialization for `+default/search-project-for-symbol-at-point`. Other `+default/...` convenience methods had already been specialized though, so maybe symbol-at-point was left out for a reason?