### PR TITLE
Revert xref-show-definitions-function binding

### DIFF
--- a/modules/completion/selectrum/config.el
+++ b/modules/completion/selectrum/config.el
@@ -83,9 +83,7 @@
 
 (use-package! consult-xref
   :commands (consult-xref)
-  :init
-  (setq xref-show-xrefs-function #'consult-xref
-        xref-show-definitions-function #'consult-xref))
+  :init (setq xref-show-xrefs-function #'consult-xref))
 
 (use-package! consult-flycheck
   :when (featurep! :checkers syntax)


### PR DESCRIPTION
I think only show-xrefs-function should be bound to counsel-xref, sorry for the noise