### PR TITLE
Selectrum: more things 2

### DIFF
--- a/modules/completion/selectrum/README.org
+++ b/modules/completion/selectrum/README.org
@@ -10,7 +10,7 @@
 - [[#prerequisites][Prerequisites]]
 - [[#prerequisites-1][Prerequisites]]
   - [[#install][Install]]
-- [[#proj-features][PROJ Features]]
+- [[#features][Features]]
   - [[#jump-to-navigation][Jump-to navigation]]
   - [[#project-search--replace][Project search & replace]]
   - [[#in-buffer-searching][In-buffer searching]]
@@ -31,7 +31,7 @@ TODO
 
 ** Module Flags
 + ~+prescient~ Enables prescient filtering and sorting for Selectrum searches.
-+ ~+orderless~ Enables prescient filtering Selectrum searches.
++ ~+orderless~ Enables orderless filtering for Selectrum searches.
 
 
 ** Plugins
@@ -68,7 +68,7 @@ sudo pacman --needed --noconfirm -S ripgrep
 sudo zypper install ripgrep
 #+END_SRC
 
-* PROJ Features
+* Features
 
 Selectrum and friends modify and use the built-in ~completing-read~ function, used by any function
 that requires completion. Due to this the full scope of these packages is too
@@ -116,12 +116,13 @@ commands.
 
 These keybindings are available while a search is active:
 
-| Keybind   | Description                                   |
-|-----------+-----------------------------------------------|
-| =C-c C-o= | Open a buffer with your search results        |
-| =C-c C-e= | Open a writable buffer of your search results |
-| =C-SPC=   | Preview the current candidate                 |
-| =C-RET=   | Open the selected candidate in other-window   |
+| Keybind   | Description                                        |
+|-----------+----------------------------------------------------|
+| =C-o=     | Open an ~embark-act~ menu to chose a useful action |
+| =C-c C-o= | Open a buffer with your search results             |
+| =C-c C-e= | Open a writable buffer of your search results      |
+| =C-SPC=   | Preview the current candidate                      |
+| =C-RET=   | Open the selected candidate in other-window        |
 
 Changes to the resulting wgrep buffer (opened by =C-c C-e=) can be committed
 with =C-c C-c= and aborted with =C-c C-k= (alternatively =ZZ= and =ZQ=, for evil
@@ -144,10 +145,10 @@ A wgrep buffer can be opened from swiper with =C-c C-e=.
 
 ** Selectrum integration for various completing commands
 *** General
-| Keybind        | Description                    |
-|----------------+--------------------------------|
-| =M-x=, =SPC := | Enhanced M-x                   |
-| =SPC '=        | Resume last Selectrum  session |
+| Keybind        | Description                   |
+|----------------+-------------------------------|
+| =M-x=, =SPC := | Enhanced M-x                  |
+| =SPC '=        | Resume last Selectrum session |
 
 *** Jump to files, buffers or projects
 | Keybind              | Description                           |

--- a/modules/completion/selectrum/TODO.org
+++ b/modules/completion/selectrum/TODO.org
@@ -34,4 +34,3 @@ In selectrum, it leads to =/foo/bar!=
 ** TODO bind =consult-lsp-diagnostics= to something?
 ** TODO test out bibtex-actions, check if more configuration should be added
 https://github.com/bdarcus/bibtex-actions
- .

--- a/modules/completion/selectrum/TODO.org
+++ b/modules/completion/selectrum/TODO.org
@@ -1,17 +1,18 @@
 * PROJ List of things not working
-** TODO Fulctions very slow on startup due to preview:
-- =consult-recent-files=
-- =consult-bookmark=
-preview deactivated for now (see consult use-package)
 ** TODO Add vanilla keybindings
 *** TODO Add keybinding for embark-act
 ** TODO =SPC s s= and =SPC s S= ~:sw~
 There isn't really a selectrum analogue to ~swiper-isearch~, ~consult-isearch~
 does something else (give you previously used isearch search terms).
-** TODO fix C-SPC
-currently after executing the action it:
-- moves the cursor to the new window if created, might not be desired in all cases
-- for some reason opens buffers in a new window (might be upstream bug?)
+** TODO =C-SPC= and live previews
+Automatic live previews have been globally disabled for speed purposes.
+=C-SPC= is partially implemented with the preview key for ~consult-*~ commands.
+Need to get it to work for other selectrum commands such =SPC h f=.
+#+begin_src emacs-lisp
+  (let ((embark-quit-after-action nil))
+    (map! :map minibuffer-local-map "C-SPC" #'embark-default-action)))
+#+end_src
+gets us close but moves the cursor to the new screen which is undesirable.
 * PROJ List of things needed for Ivy parity
 ** TODO Icons
 https://github.com/minad/marginalia/issues/59
@@ -32,3 +33,4 @@ In selectrum, it leads to =/foo/bar!=
 ** TODO bind =consult-lsp-diagnostics= to something?
 ** TODO test out bibtex-actions, check if more configuration should be added
 https://github.com/bdarcus/bibtex-actions
+ .

--- a/modules/completion/selectrum/TODO.org
+++ b/modules/completion/selectrum/TODO.org
@@ -19,7 +19,15 @@ https://github.com/minad/marginalia/issues/59
 In ivy, backspace on =/foo/bar/!= (where =!= is the cursor) leads to =/foo/!=
 In selectrum, it leads to =/foo/bar!=
 ** TODO =SPC s B=
-** TODO ~:pg~ support
+** TODO modules to look over
+- lookup
+- taskrunner (doesn't seem to be an interface yet)
+- pass (creating embark-pass can't be that hard)
+- irc
+- org (check, might be fine)
+- counsel-minibuffer-history analogue
+- counsel-company analogue
+- bibtex
 * PROJ Other
 ** TODO bind =consult-lsp-diagnostics= to something?
 ** TODO test out bibtex-actions, check if more configuration should be added

--- a/modules/completion/selectrum/TODO.org
+++ b/modules/completion/selectrum/TODO.org
@@ -13,6 +13,7 @@ Need to get it to work for other selectrum commands such =SPC h f=.
     (map! :map minibuffer-local-map "C-SPC" #'embark-default-action)))
 #+end_src
 gets us close but moves the cursor to the new screen which is undesirable.
+** TODO =C-C C-e= wgrep fun
 * PROJ List of things needed for Ivy parity
 ** TODO Icons
 https://github.com/minad/marginalia/issues/59

--- a/modules/completion/selectrum/autoload/evil.el
+++ b/modules/completion/selectrum/autoload/evil.el
@@ -1,0 +1,14 @@
+;; completion/selectrum/autoload/evil.el -*- lexical-binding: t; -*-
+;;;###if (featurep! :editor evil)
+
+;;;###autoload (autoload '+selectrum:project-search "completion/ivy/autoload/evil" nil t)
+(evil-define-command +selectrum:project-search (query &optional all-files-p)
+  "Ex interface for `+selectrum/project-search'."
+  (interactive "<a><!>")
+  (+selectrum/project-search all-files-p query))
+
+;;;###autoload (autoload '+selectrum:project-search-from-cwd "completion/ivy/autoload/evil" nil t)
+(evil-define-command +selectrum:project-search-from-cwd (query &optional recurse-p)
+  "Ex interface for `+selectrum/project-search-from-cwd'."
+  (interactive "<a><!>")
+  (+selectrum/project-search-from-cwd (not recurse-p) query))

--- a/modules/completion/selectrum/config.el
+++ b/modules/completion/selectrum/config.el
@@ -50,7 +50,7 @@
                                     orderless-regexp))
   :config
   (setq completion-styles '(orderless))
-  (setq orderless-skip-highlighting (lambda () selectrum-active-p))
+  (setq orderless-skip-highlighting (lambda () selectrum-is-active))
   (setq selectrum-refine-candidates-function #'orderless-filter)
   (setq selectrum-highlight-candidates-function #'orderless-highlight-matches)
   (setq orderless-matching-styles '(orderless-regexp)

--- a/modules/completion/selectrum/config.el
+++ b/modules/completion/selectrum/config.el
@@ -81,8 +81,9 @@
   (setq consult-project-root-function #'doom-project-root)
   (setq completion-in-region-function #'consult-completion-in-region)
   (setq consult-narrow-key "<")
-  (setf (alist-get #'consult-bookmark consult-config) (list :preview-key nil))
-  (setf (alist-get #'consult-recent-file consult-config) (list :preview-key nil))
+  (setf (alist-get #'consult-bookmark consult-config) (list :preview-key (kbd "C-SPC")))
+  (setf (alist-get #'consult-recent-file consult-config) (list :preview-key (kbd "C-SPC")))
+  (setf (alist-get #'consult--grep consult-config) (list :preview-key (kbd "C-SPC")))
   (setq consult-line-numbers-widen t)
   (setq consult-async-input-debounce 0.5)
   (setq consult-async-input-throttle 0.8))
@@ -107,9 +108,7 @@
    :desc "Open target with sudo" "s" #'sudo-edit
    :desc "Open target with vlf" "l" #'vlf
    :map embark-file-map
-   :desc "Cycle marginalia views" "A" #'marginalia-cycle )
-  (let ((embark-quit-after-action nil))
-    (map! :map minibuffer-local-map "C-SPC" #'embark-default-action)))
+   :desc "Cycle marginalia views" "A" #'marginalia-cycle))
 
 (use-package! marginalia
   :hook (doom-first-input . marginalia-mode)

--- a/modules/completion/selectrum/packages.el
+++ b/modules/completion/selectrum/packages.el
@@ -12,8 +12,6 @@
 (package! consult :pin "e04a404c8d8ca137be2b3b7cf664a11712639c31")
 (when (featurep! :checkers syntax)
   (package! consult-flycheck :pin "e04a404c8d8ca137be2b3b7cf664a11712639c31"))
-(when (featurep! :tools lsp)
-  (package! consult-lsp :pin "ed3cfd2e67fc5117819c0c739814780bb4c2d716"))
 
 (package! embark :pin "4d7e8e4d3be7aaff56730f76a066db2acad65371")
 (package! embark-consult :pin "4d7e8e4d3be7aaff56730f76a066db2acad65371")

--- a/modules/config/default/+evil-bindings.el
+++ b/modules/config/default/+evil-bindings.el
@@ -695,8 +695,8 @@
        :desc "Jump to mark"                 "r" #'evil-show-marks
        :desc "Search buffer"                "s" #'+default/search-buffer
        :desc "Search buffer for thing at point" "S"
-       (cond ((featurep! :completion ivy)  #'swiper-isearch-thing-at-point)
-             ((featurep! :completion selectrum)  #'+consult-line-symbol-at-point))
+       (cond ((featurep! :completion ivy)       #'swiper-isearch-thing-at-point)
+             ((featurep! :completion selectrum) #'+consult-line-symbol-at-point))
        :desc "Dictionary"                   "t" #'+lookup/dictionary-definition
        :desc "Thesaurus"                    "T" #'+lookup/synonyms)
 

--- a/modules/config/default/config.el
+++ b/modules/config/default/config.el
@@ -16,7 +16,9 @@
                 ((featurep! :completion helm)
                  '(helm-map
                    helm-rg-map
-                   helm-read-file-map))))
+                   helm-read-file-map))
+                ((featurep! :completion selectrum)
+                 '(selectrum-minibuffer-map))))
   "A list of all the keymaps used for the minibuffer.")
 
 

--- a/modules/editor/evil/+commands.el
+++ b/modules/editor/evil/+commands.el
@@ -68,7 +68,10 @@
 
       ((featurep! :completion helm)
        (evil-ex-define-cmd "pg[rep]"   #'+helm:project-search)
-       (evil-ex-define-cmd "pg[grep]d" #'+helm:project-search-from-cwd)))
+       (evil-ex-define-cmd "pg[grep]d" #'+helm:project-search-from-cwd))
+      ((featurep! :completion selectrum)
+       (evil-ex-define-cmd "pg[rep]"   #'+selectrum:project-search)
+       (evil-ex-define-cmd "pg[grep]d" #'+selectrum:project-search-from-cwd)))
 
 ;;; Project tools
 (evil-ex-define-cmd "com[pile]"   #'+evil:compile)

--- a/modules/email/mu4e/config.el
+++ b/modules/email/mu4e/config.el
@@ -42,10 +42,11 @@
         mu4e-context-policy 'pick-first
         ;; compose with the current context, or ask
         mu4e-compose-context-policy 'ask-if-none
-        ;; use helm/ivy
+        ;; use helm/ivy/selectrum
         mu4e-completing-read-function
-        (cond ((featurep! :completion ivy) #'ivy-completing-read)
-              ((featurep! :completion helm) #'completing-read)
+        (cond ((featurep! :completion ivy)       #'ivy-completing-read)
+              ((featurep! :completion helm)      #'completing-read)
+              ((featurep! :completion selectrum) #'completing-read)
               (t #'ido-completing-read))
         ;; no need to ask
         mu4e-confirm-quit nil

--- a/modules/email/notmuch/config.el
+++ b/modules/email/notmuch/config.el
@@ -102,3 +102,9 @@ OR a shell command string such as
   :when (featurep! :completion helm)
   :commands helm-notmuch
   :after notmuch)
+
+
+(use-package! consult-notmuch
+  :when (featurep! :completion selectrum)
+  :commands consult-notmuch
+  :after notmuch)

--- a/modules/email/notmuch/packages.el
+++ b/modules/email/notmuch/packages.el
@@ -7,3 +7,5 @@
   (package! counsel-notmuch :pin "a4a1562935e4180c42524c51609d1283e9be0688"))
 (when (featurep! :completion helm)
   (package! helm-notmuch :pin "97a01497e079a7b6505987e9feba6b603bbec288"))
+(when (featurep! :completion selectrum)
+  (package! consult-notmuch :pin "67cf219fcce211237347a783ce6982402341d5fd"))

--- a/modules/tools/lsp/packages.el
+++ b/modules/tools/lsp/packages.el
@@ -10,4 +10,6 @@
   (when (featurep! :completion ivy)
     (package! lsp-ivy :pin "515e5977b3d1f6cb521984f084868f28efd47e72"))
   (when (featurep! :completion helm)
-    (package! helm-lsp :pin "74a02f89088484c42ffc184ece338b73abd4d6f6")))
+    (package! helm-lsp :pin "74a02f89088484c42ffc184ece338b73abd4d6f6"))
+  (when (featurep! :completion selectrum)
+    (package! consult-lsp :pin "ed3cfd2e67fc5117819c0c739814780bb4c2d716")))


### PR DESCRIPTION
- moving the consult-lsp package declaration to the lsp module where it belongs
- improving ivy parity and documenting where it's still lacking
- reworking the live preview so C-SPC works on the slow consult buffers, remove the current hack for selectrum buffers because it wasn't really any good
- README updates

