### PR TITLE
Setup consult as completion-in-region fallback

### DIFF
--- a/modules/completion/selectrum/config.el
+++ b/modules/completion/selectrum/config.el
@@ -76,6 +76,7 @@
     [remap switch-to-buffer-other-frame]  #'consult-buffer-other-frame
     [remap yank-pop]                      #'consult-yank-pop
     [remap describe-bindings]             #'embark-bindings)
+  (setq completion-in-region-function #'consult-completion-in-region)
   :config
   (recentf-mode)
   (setq consult-project-root-function #'doom-project-root)


### PR DESCRIPTION
This allows `corfu` users to enable corfu and let it noop when _not_ using a graphical display.

Having the function setup in `init` means company can properly override it when it’s activated later.